### PR TITLE
deps: remove debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@
  * Module dependencies.
  */
 
-var debug = require('debug')('finalhandler')
 var escapeHtml = require('escape-html')
 var http = require('http')
 var onFinished = require('on-finished')
@@ -53,7 +52,6 @@ function finalhandler(req, res, options) {
 
     // ignore 404 on in-flight response
     if (!err && res._header) {
-      debug('cannot 404 after headers sent')
       return
     }
 
@@ -80,8 +78,6 @@ function finalhandler(req, res, options) {
       res.statusCode = 404
       msg = 'Cannot ' + escapeHtml(req.method) + ' ' + escapeHtml(req.originalUrl || req.url) + '\n'
     }
-
-    debug('default %s', res.statusCode)
 
     // schedule onerror callback
     if (err && onerror) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "pillarjs/finalhandler",
   "dependencies": {
-    "debug": "~2.1.1",
     "escape-html": "1.0.1",
     "on-finished": "~2.2.0"
   },


### PR DESCRIPTION
It is extraneous dependency if you do not need debug. Even for debug, it would be better to have events system instead of using `debug` package.