### PR TITLE
Allow to simply pass a status code as error

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,11 @@ function finalhandler(req, res, options) {
         status = err.status
       }
 
+      // allow to pass just the status code
+      if (typeof err === 'number') {
+        status = err
+      }
+
       // default status code to 500
       if (!status || status < 400) {
         status = 500


### PR DESCRIPTION
Instead of a full error object with a `status` or `statusCode` entry, allow to pass just the number of the status code.