### PR TITLE
don't block debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "pillarjs/finalhandler",
   "dependencies": {
-    "debug": "2.6.3",
+    "debug": "^2.6.3",
     "encodeurl": "~1.0.1",
     "escape-html": "~1.0.3",
     "on-finished": "~2.3.0",


### PR DESCRIPTION
Hello ! This will allow yarn or npm to do better optimizations and avoid multiple debug package.