### PR TITLE
Unpin debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "pillarjs/finalhandler",
   "dependencies": {
-    "debug": "2.6.4",
+    "debug": "^2.6.4",
     "encodeurl": "~1.0.1",
     "escape-html": "~1.0.3",
     "on-finished": "~2.3.0",


### PR DESCRIPTION
Is there any reason it is pinned to that exact version?