### PR TITLE
Use res.headersSent to detect if the headers have been sent

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,9 +87,10 @@ function finalhandler (req, res, options) {
     var headers
     var msg
     var status
+    var headersSent = res.headersSent || res._header
 
     // ignore 404 on in-flight response
-    if (!err && res._header) {
+    if (!err && headersSent) {
       debug('cannot 404 after headers sent')
       return
     }
@@ -125,7 +126,7 @@ function finalhandler (req, res, options) {
     }
 
     // cannot actually respond
-    if (res._header) {
+    if (headersSent) {
       debug('cannot %d after headers sent', status)
       req.socket.destroy()
       return


### PR DESCRIPTION
@sebdeckers found this in https://github.com/nodejs/http2/pull/130.

This PR updates the module so that it uses a public documented property wherever possible.

I do not think this is fully working with the http2 core module, as it is destroying the socket, while you would have to destroy the stream in case of http2. We will address that later on.