### PR TITLE
debug -> 2.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "pillarjs/finalhandler",
   "dependencies": {
-    "debug": "2.6.7",
+    "debug": "2.6.8",
     "encodeurl": "~1.0.1",
     "escape-html": "~1.0.3",
     "on-finished": "~2.3.0",


### PR DESCRIPTION
`debug: 2.6.7` has a breaking change in it:

https://github.com/visionmedia/debug/commit/cae07b70c968bdcadffff452dee8613522857888#diff-b056c1ad802eb5041886154caaf3a3d4

This causes:

```
  if (window && window.process && window.process.type === 'renderer') {
      ^

ReferenceError: window is not defined
```

The change was reversed in `debug: 2.6.8`

https://github.com/visionmedia/debug/commit/2482e08e4ef36416154ee27e9a2d60e568a01d48#diff-b056c1ad802eb5041886154caaf3a3d4

