### PR TITLE
Fix for overwrite of CSP header even if value was already set

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,8 +251,12 @@ function send (req, res, status, headers, message) {
     setHeaders(res, headers)
 
     // security headers
-    res.setHeader('Content-Security-Policy', "default-src 'self'")
     res.setHeader('X-Content-Type-Options', 'nosniff')
+
+    if (!res.getHeader('Content-Security-Policy')) {
+      // only set csp header if not available
+      res.setHeader('Content-Security-Policy', "default-src 'self'")
+    }
 
     // standard headers
     res.setHeader('Content-Type', 'text/html; charset=utf-8')

--- a/test/test.js
+++ b/test/test.js
@@ -270,7 +270,7 @@ describe('finalhandler(req, res)', function () {
       .expect(404, done)
     })
 
-    it('should node include Content-Security-Policy header if already set', function (done) {
+    it('should not include Content-Security-Policy header if already set', function (done) {
       request(createServer(function (req, res, next) {
         res.setHeader('Content-Security-Policy', "frame-ancestors 'self'")
         next()

--- a/test/test.js
+++ b/test/test.js
@@ -263,10 +263,20 @@ describe('finalhandler(req, res)', function () {
       .expect(404, done)
     })
 
-    it('should includeContent-Security-Policy header', function (done) {
+    it('should include Content-Security-Policy header', function (done) {
       request(createServer())
       .get('/foo')
       .expect('Content-Security-Policy', "default-src 'self'")
+      .expect(404, done)
+    })
+
+    it('should node include Content-Security-Policy header if already set', function (done) {
+      request(createServer(function (req, res, next) {
+        res.setHeader('Content-Security-Policy', "frame-ancestors 'self'")
+        next()
+      }))
+      .get('/foo')
+      .expect('Content-Security-Policy', "frame-ancestors 'self'")
       .expect(404, done)
     })
 


### PR DESCRIPTION
Prior to this commit, the CSP header would be set forcibly even if it already had already been set. Changes include the fix and tests to support that case.