### PR TITLE
Allow favicon requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,7 +282,7 @@ function send (req, res, status, headers, message) {
     setHeaders(res, headers)
 
     // security headers
-    res.setHeader('Content-Security-Policy', "default-src 'none'")
+    res.setHeader('Content-Security-Policy', "default-src 'none'; img-src " + req.headers.host + "/favicon.ico")
     res.setHeader('X-Content-Type-Options', 'nosniff')
 
     // standard headers

--- a/test/test.js
+++ b/test/test.js
@@ -277,10 +277,10 @@ describe('finalhandler(req, res)', function () {
         .expect(404, done)
     })
 
-    it('should includeContent-Security-Policy header', function (done) {
+    it('should include Content-Security-Policy header', function (done) {
       request(createServer())
         .get('/foo')
-        .expect('Content-Security-Policy', "default-src 'none'")
+        .expect('Content-Security-Policy', /^default-src 'none'; img-src 127\.0\.0\.1:\d+\/favicon\.ico$/)
         .expect(404, done)
     })
 
@@ -317,10 +317,10 @@ describe('finalhandler(req, res)', function () {
         .expect(500, done)
     })
 
-    it('should includeContent-Security-Policy header', function (done) {
+    it('should include Content-Security-Policy header', function (done) {
       request(createServer(createError('boom!')))
         .get('/foo')
-        .expect('Content-Security-Policy', "default-src 'none'")
+        .expect('Content-Security-Policy', /^default-src 'none'; img-src 127\.0\.0\.1:\d+\/favicon\.ico$/)
         .expect(500, done)
     })
 


### PR DESCRIPTION
This PR restores the ability for favicons to be requested on pages served by `finalhandler`.

I noticed that while using `webpack-dev-server` to test a favicon (which I typically do by requesting a page that will 404), Chrome's request for the favicon was being denied by the content security policy.

After some research it turns out that the [img-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src) CSP directive also governs favicons (emphasis mine):

> The HTTP [`Content-Security-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) `img-src` directive specifies valid sources of images and **favicons**.

I also found #26, where it was stated that:

> There is no reason to allow all this functionality since the error page doesn't use any of these browser features.

But this is not true for `img-src`, since the browser itself requests `/favicon.ico` for error pages.

This change to the CSP should only allow image requests to `/favicon.ico` on the same host as the original request. I think that's as restrictive as it can be whilst retaining support for favicons.