### PR TITLE
remove warning when used with HTTP2

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,13 @@ var parseUrl = require('parseurl')
 var statuses = require('statuses')
 var unpipe = require('unpipe')
 
+var http2
+try {
+  http2 = require('http2')
+} catch (e) {
+  http2 = null
+}
+
 /**
  * Module variables.
  * @private
@@ -276,7 +283,9 @@ function send (req, res, status, headers, message) {
 
     // response status
     res.statusCode = status
-    res.statusMessage = statuses[status]
+    if (!isHTTP2Response(res)) {
+      res.statusMessage = statuses[status]
+    }
 
     // response headers
     setHeaders(res, headers)
@@ -328,4 +337,15 @@ function setHeaders (res, headers) {
     var key = keys[i]
     res.setHeader(key, headers[key])
   }
+}
+
+/**
+ * Check if a response object is HTTP2.
+ *
+ * @param {OutgoingMessage|Http2ServerResponse} res
+ * @private
+ */
+
+function isHTTP2Response (res) {
+  return http2 && res instanceof http2.Http2ServerResponse
 }

--- a/test/test.js
+++ b/test/test.js
@@ -513,3 +513,33 @@ describe('finalhandler(req, res)', function () {
     })
   })
 })
+
+describe('HTTP2', function () {
+  it('should not set statusMessage for HTTP2 response', function (done) {
+    var http2
+    try {
+      http2 = require('http2')
+    } catch (e) {
+      return done()
+    }
+
+    process.once('warning', function (warning) {
+      assert.fail(warning)
+    })
+
+    var server = http2.createServer(function (req, res) {
+      var done = finalhandler(req, res)
+      done()
+    })
+
+    server.listen(function () {
+      var address = server.address()
+      var client = http2.connect('http://localhost:' + address.port)
+      client.request({ ':path': '/' }).on('response', function () {
+        client.close()
+        server.close()
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
The HTTP2 spec does not support sending a status message, so when `res.statusMessage` is set a process warning is emitted.