### PR TITLE
Ignore status message for HTTP/2

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,7 +276,9 @@ function send (req, res, status, headers, message) {
 
     // response status
     res.statusCode = status
-    res.statusMessage = statuses.message[status]
+    if (req.httpVersionMajor < 2) {
+      res.statusMessage = statuses.message[status]
+    }
 
     // remove any content headers
     res.removeHeader('Content-Encoding')

--- a/test/test.js
+++ b/test/test.js
@@ -582,6 +582,8 @@ describe('finalhandler(req, res)', function () {
     it('should respond 404 without warning', function (done) {
       var warned = false
       process.on('warning', function (warning) {
+        if (warning.name !== 'UnsupportedWarning') return
+        if (!warning.message.match(/Status message is not supported/)) return
         warned = true
       })
 


### PR DESCRIPTION
To avoid setting status message that is not supported by HTTP/2, checked if the request's HTTP major version is less than 2.
Without this fix some of apps using this package shows warning as follows
```
(node:49588) UnsupportedWarning: Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)
```