### PR TITLE
ci: fix errors in ci github action for node 8 and 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         - Node.js 19.x
         - Node.js 20.x
         - Node.js 21.x
+        - Node.js 22.x
         
         include:
         - name: Node.js 0.8
@@ -124,7 +125,10 @@ jobs:
 
         - name: Node.js 21.x
           node-version: "21.7"
-          
+
+        - name: Node.js 22.x
+          node-version: "22.0"
+
     steps:
     - uses: actions/checkout@v4
 
@@ -205,7 +209,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - name: Uploade code coverage
+    - name: Upload code coverage
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.github_token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
         - Node.js 15.x
         - Node.js 16.x
         - Node.js 17.x
+        - Node.js 18.x
+        - Node.js 19.x
+        - Node.js 20.x
 
         include:
         - name: Node.js 0.8
@@ -75,11 +78,11 @@ jobs:
 
         - name: Node.js 8.x
           node-version: "8.16"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 9.x
           node-version: "9.11"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 10.x
           node-version: "10.24"
@@ -108,6 +111,15 @@ jobs:
 
         - name: Node.js 17.x
           node-version: "17.9"
+
+        - name: Node.js 18.x
+          node-version: "18.14"
+
+        - name: Node.js 19.x
+          node-version: "19.6"
+
+        - name: Node.js 20.x
+          node-version: "20.12"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,12 @@ jobs:
         dirname "$(nvm which ${{ matrix.node-version }})" >> "$GITHUB_PATH"
 
     - name: Configure npm
-      run: npm config set shrinkwrap false
+      run: |
+        if [[ "$(npm config get package-lock)" == "true" ]]; then
+          npm config set package-lock false
+        else
+          npm config set shrinkwrap false
+        fi
 
     - name: Remove npm module(s) ${{ matrix.npm-rm }}
       run: npm rm --silent --save-dev ${{ matrix.npm-rm }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
         - Node.js 18.x
         - Node.js 19.x
         - Node.js 20.x
-
+        - Node.js 21.x
+        
         include:
         - name: Node.js 0.8
           node-version: "0.8"
@@ -121,6 +122,9 @@ jobs:
         - name: Node.js 20.x
           node-version: "20.12"
 
+        - name: Node.js 21.x
+          node-version: "21.7"
+          
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           node-version: "21.7"
           
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}


### PR DESCRIPTION
This PR fixes [nyc](https://github.com/istanbuljs/nyc) version to 14.1.1 when running tests in node 8 or node 9. `nyc 15.x` requires a `yargs` package version that requires node >=10.

I've also added the latest versions of node (18, 19 and 20) to the matrix.

Related to https://github.com/jshttp/http-errors/issues/108

> [!WARNING]
> The CI is failing for one test in node@21 and node@22. The error has nothing to do with this PR, because those node versions were not tested before and with this PR we discovered it.