### PR TITLE
fix: gracefully handle when handling an error and socket is null

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==================
+
+  * Gracefully handle when handling an error and socket is null
+
 1.2.0 / 2022-03-22
 ==================
 

--- a/index.js
+++ b/index.js
@@ -125,7 +125,9 @@ function finalhandler (req, res, options) {
     // cannot actually respond
     if (headersSent(res)) {
       debug('cannot %d after headers sent', status)
-      req.socket.destroy()
+      if (req.socket) {
+        req.socket.destroy()
+      }
       return
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -571,4 +571,25 @@ describe('finalhandler(req, res)', function () {
         })
     })
   })
+
+  if (parseInt(process.version.split('.')[0].replace(/^v/, ''), 10) > 11) {
+    describe('req.socket', function () {
+      it('should not throw when socket is null', function (done) {
+        request(createServer(function (req, res, next) {
+          res.statusCode = 200
+          res.end('ok')
+          process.nextTick(function () {
+            req.socket = null
+            next(new Error())
+          })
+        }))
+          .get('/')
+          .end(function () {
+            assert.strictEqual(this.res.statusCode, 200)
+            assert.strictEqual(this.res.text, 'ok')
+            done()
+          })
+      })
+    })
+  }
 })


### PR DESCRIPTION
`req.socket` can be set to null in some circumstances (see #42). This adds a check for this case which only occurs when an error is raised and the socket is already nulled out.