### PR TITLE
fix(package.json) Explicit drop support for node<18

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">= 0.8"
+    "node": ">= 18"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Followup to #54:
That PR added a statement that support for node<18 is dropped, and amended the CI accordingly.

This PR builds on that and makes this support statement explicit in the package.json.