### PR TITLE
Remove encodeurl as a dep

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@
  */
 
 var debug = require('debug')('finalhandler')
-var encodeUrl = require('encodeurl')
 var escapeHtml = require('escape-html')
 var onFinished = require('on-finished')
 var parseUrl = require('parseurl')
@@ -112,7 +111,7 @@ function finalhandler (req, res, options) {
     } else {
       // not found
       status = 404
-      msg = 'Cannot ' + req.method + ' ' + encodeUrl(getResourceName(req))
+      msg = 'Cannot ' + req.method + ' ' + getResourceName(req)
     }
 
     debug('default %s', status)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "repository": "pillarjs/finalhandler",
   "dependencies": {
     "debug": "2.6.9",
-    "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",
     "on-finished": "2.4.1",
     "parseurl": "~1.3.3",

--- a/test/test.js
+++ b/test/test.js
@@ -243,7 +243,7 @@ var topDescribe = function (type, createServer) {
     it('should escape method and pathname characters', function (done) {
       (type === 'http2' ? rawrequestHTTP2 : rawrequest)(createServer())
         .get('/<la\'me>')
-        .expect(404, /<pre>Cannot GET \/%3Cla&#39;me%3E<\/pre>/, done)
+        .expect(404, /<pre>Cannot GET \/&lt;la&#39;me&gt;<\/pre>/, done)
     })
 
     it('should fallback to generic pathname without URL', function (done) {


### PR DESCRIPTION
Closes https://github.com/pillarjs/finalhandler/issues/60#issuecomment-2341323316. It already escapes the HTML which should be good enough for visualizing, I'm not sure there's much value in also encoding it since that makes it not match the actual path used in the URL, which may be slightly confusing.