### PR TITLE
fix: remove unpipe package and use native unpipe method

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==================
+
+  * remove `unpipe` package and use native `unpipe()` method
+
 v2.0.0 / 2024-09-02
 ==================
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ var escapeHtml = require('escape-html')
 var onFinished = require('on-finished')
 var parseUrl = require('parseurl')
 var statuses = require('statuses')
-var unpipe = require('unpipe')
 
 /**
  * Module variables.
@@ -313,7 +312,7 @@ function send (req, res, status, headers, message) {
   }
 
   // unpipe everything from the request
-  unpipe(req)
+  req.unpipe()
 
   // flush the request
   onFinished(req, write)

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "escape-html": "~1.0.3",
     "on-finished": "2.4.1",
     "parseurl": "~1.3.3",
-    "statuses": "2.0.1",
-    "unpipe": "~1.0.0"
+    "statuses": "2.0.1"
   },
   "devDependencies": {
     "eslint": "7.32.0",


### PR DESCRIPTION
The [`unpipe`](https://www.npmjs.com/package/unpipe) package was used to unpipes all destinations from a given stream.

Taken from the unpipe readme:

> With stream 2+, this is equivalent to stream.unpipe(). When used with streams 1 style streams (typically Node.js 0.8 and below), this module attempts to undo the actions done in stream.pipe(dest).

As our minimum supported Node version is v18 the `unpipe` package is no longer needed.