### PR TITLE
cleanup: remove unnecessary devDependency `readable-stream`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==================
+
+  * remove unnecessary devDependency `readable-stream`
+
 v2.0.0 / 2024-09-02
 ==================
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "eslint-plugin-standard": "4.1.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
-    "readable-stream": "2.3.6",
     "safe-buffer": "5.2.1",
     "supertest": "6.2.4"
   },

--- a/test/support/sws.js
+++ b/test/support/sws.js
@@ -1,4 +1,4 @@
-var stream = require('readable-stream')
+var stream = require('stream')
 var util = require('util')
 
 module.exports = SlowWriteStream


### PR DESCRIPTION
With support limited to Node.js 18 and newer, the `readable-stream` devDependency is no longer necessary and can be removed.