### PR TITLE
cleanup: remove unnecessary devDependency `safe-buffer`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==================
+
+  * remove unnecessary devDependency `safe-buffer`
+
 v2.0.0 / 2024-09-02
 ==================
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "readable-stream": "2.3.6",
-    "safe-buffer": "5.2.1",
     "supertest": "6.2.4"
   },
   "files": [

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,3 @@
-
-var Buffer = require('safe-buffer').Buffer
 var finalhandler = require('..')
 var http = require('http')
 


### PR DESCRIPTION
With support limited to Node.js 18 and newer, the `safe-buffer` devDependency is no longer necessary and can be removed.