### PR TITLE
refactor: remove http2 support check from tests

### DIFF
--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -1,14 +1,7 @@
 var assert = require('assert')
 var finalhandler = require('../..')
 var http = require('http')
-
-var http2
-
-try {
-  http2 = require('http2')
-} catch (_err) {
-  // Nothing
-}
+var http2 = require('http2')
 
 var request = require('supertest')
 var SlowWriteStream = require('./sws')

--- a/test/test.js
+++ b/test/test.js
@@ -3,14 +3,6 @@ var Buffer = require('safe-buffer').Buffer
 var finalhandler = require('..')
 var http = require('http')
 
-var http2
-
-try {
-  http2 = require('http2')
-} catch (_err) {
-  // Nothing
-}
-
 var utils = require('./support/utils')
 
 var assert = utils.assert
@@ -673,15 +665,9 @@ var topDescribe = function (type, createServer) {
 }
 
 var servers = [
-  ['http', createHTTPServer]
+  ['http', createHTTPServer],
+  ['http2', createHTTP2Server]
 ]
-
-var nodeVersion = process.versions.node.split('.').map(Number)
-
-// `superagent` only supports `http2` since Node.js@10
-if (http2 && nodeVersion[0] >= 10) {
-  servers.push(['http2', createHTTP2Server])
-}
 
 for (var i = 0; i < servers.length; i++) {
   var tests = topDescribe.bind(undefined, servers[i][0], servers[i][1])


### PR DESCRIPTION
Removed the http2 support check from tests, as Node.js 18 and newer always has http2 support.