### PR TITLE
refactor: replace setHeaders function with optimized inline header setting

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@ unreleased
   * remove unnecessary devDependency `readable-stream`
   * refactor: use object spread to copy error headers
   * refactor: use replaceAll instead of replace with a regex
+  * refactor: replace setHeaders function with optimized inline header setting
 
 v2.0.0 / 2024-09-02
 ==================

--- a/index.js
+++ b/index.js
@@ -259,7 +259,9 @@ function send (req, res, status, headers, message) {
     res.removeHeader('Content-Range')
 
     // response headers
-    setHeaders(res, headers)
+    for (const [key, value] of Object.entries(headers ?? {})) {
+      res.setHeader(key, value)
+    }
 
     // security headers
     res.setHeader('Content-Security-Policy', "default-src 'none'")
@@ -288,24 +290,4 @@ function send (req, res, status, headers, message) {
   // flush the request
   onFinished(req, write)
   req.resume()
-}
-
-/**
- * Set response headers from an object.
- *
- * @param {OutgoingMessage} res
- * @param {object} headers
- * @private
- */
-
-function setHeaders (res, headers) {
-  if (!headers) {
-    return
-  }
-
-  var keys = Object.keys(headers)
-  for (var i = 0; i < keys.length; i++) {
-    var key = keys[i]
-    res.setHeader(key, headers[key])
-  }
 }


### PR DESCRIPTION
Replaced the `setHeaders` function with a loop that sets headers directly using `Object.entries`. This change eliminates the need for the separate `setHeaders` function.