### PR TITLE
chore: update test dependencies

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@ unreleased
 
   * remove `ServerResponse.headersSent` support check
   * remove setImmediate support check
+  * update test dependencies
   * remove unnecessary devDependency `safe-buffer`
   * remove `unpipe` package and use native `unpipe()` method
   * remove unnecessary devDependency `readable-stream`

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "5.2.0",
     "eslint-plugin-standard": "4.1.0",
-    "mocha": "10.0.0",
-    "nyc": "15.1.0",
-    "supertest": "6.2.4"
+    "mocha": "^11.0.1",
+    "nyc": "^17.1.0",
+    "supertest": "^7.0.0"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
Updated `mocha`, `nyc`, and `supertest` to their latest versions.