### PR TITLE
refactor: remove `ServerResponse.headersSent` support check

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==================
 
+  * remove `ServerResponse.headersSent` support check
   * remove unnecessary devDependency `safe-buffer`
   * remove `unpipe` package and use native `unpipe()` method
   * remove unnecessary devDependency `readable-stream`

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function finalhandler (req, res, options) {
     var status
 
     // ignore 404 on in-flight response
-    if (!err && headersSent(res)) {
+    if (!err && res.headersSent) {
       debug('cannot 404 after headers sent')
       return
     }
@@ -122,7 +122,7 @@ function finalhandler (req, res, options) {
     }
 
     // cannot actually respond
-    if (headersSent(res)) {
+    if (res.headersSent) {
       debug('cannot %d after headers sent', status)
       if (req.socket) {
         req.socket.destroy()
@@ -243,20 +243,6 @@ function getResponseStatusCode (res) {
   }
 
   return status
-}
-
-/**
- * Determine if the response headers have been sent.
- *
- * @param {object} res
- * @returns {boolean}
- * @private
- */
-
-function headersSent (res) {
-  return typeof res.headersSent !== 'boolean'
-    ? Boolean(res._header)
-    : res.headersSent
 }
 
 /**


### PR DESCRIPTION
`http.ServerResponse.headersSent` was added in v0.9.3. 
`http2.Http2ServerResponse.headersSent` was added in v8.4.0