### PR TITLE
chore(deps): update `debug` to ^4.4.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,9 @@
 unreleased
 ==================
 
-  * deps: encodeurl@^2.0.0
+  * deps: 
+    * encodeurl@^2.0.0
+    * debug@^4.4.0
   * remove `ServerResponse.headersSent` support check
   * remove setImmediate support check
   * update test dependencies

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "pillarjs/finalhandler",
   "dependencies": {
-    "debug": "2.6.9",
+    "debug": "^4.4.0",
     "encodeurl": "^2.0.0",
     "escape-html": "~1.0.3",
     "on-finished": "2.4.1",


### PR DESCRIPTION
This PR addresses the issue of multiple versions of the `debug` package being installed when using Express v5, which currently results in **four different versions** of `debug`. By updating the `debug` dependency within `finalhandler`, we can eliminate one of these redundant versions.

[Dependency Graph for Express v5](https://npmgraph.js.org/?q=express%405)

Related to: 
* https://github.com/expressjs/express/pull/6313
* https://github.com/expressjs/body-parser/pull/579