### PR TITLE
refactor: use object spread to copy error headers

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@ unreleased
   * remove unnecessary devDependency `safe-buffer`
   * remove `unpipe` package and use native `unpipe()` method
   * remove unnecessary devDependency `readable-stream`
+  * refactor: use object spread to copy error headers
 
 v2.0.0 / 2024-09-02
 ==================

--- a/index.js
+++ b/index.js
@@ -144,15 +144,7 @@ function getErrorHeaders (err) {
     return undefined
   }
 
-  var headers = Object.create(null)
-  var keys = Object.keys(err.headers)
-
-  for (var i = 0; i < keys.length; i++) {
-    var key = keys[i]
-    headers[key] = err.headers[key]
-  }
-
-  return headers
+  return { ...err.headers }
 }
 
 /**


### PR DESCRIPTION
Refactored the `getErrorHeaders` function to use object spread syntax to copy error headers, replacing the manual loop.