### PR TITLE
refactor: use `replaceAll` instead of `replace` with a regex

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@ unreleased
   * remove `unpipe` package and use native `unpipe()` method
   * remove unnecessary devDependency `readable-stream`
   * refactor: use object spread to copy error headers
+  * refactor: use replaceAll instead of replace with a regex
 
 v2.0.0 / 2024-09-02
 ==================

--- a/index.js
+++ b/index.js
@@ -23,9 +23,6 @@ var statuses = require('statuses')
  * @private
  */
 
-var DOUBLE_SPACE_REGEXP = /\x20{2}/g
-var NEWLINE_REGEXP = /\n/g
-
 var isFinished = onFinished.isFinished
 
 /**
@@ -37,8 +34,8 @@ var isFinished = onFinished.isFinished
 
 function createHtmlDocument (message) {
   var body = escapeHtml(message)
-    .replace(NEWLINE_REGEXP, '<br>')
-    .replace(DOUBLE_SPACE_REGEXP, ' &nbsp;')
+    .replaceAll('\n', '<br>')
+    .replaceAll('  ', ' &nbsp;')
 
   return '<!DOCTYPE html>\n' +
     '<html lang="en">\n' +


### PR DESCRIPTION
Replaced `String.prototype.replace` with a regex with `String.prototype.replaceAll` for:  
  - Double spaces (`/\x20{2}/g`)  
  - Newlines (`/\n/g`)  

**Why?**
- `replaceAll` is more efficient for direct string replacements
- Reduces regex overhead

