### PR TITLE
test: modernize test suite and remove obsolete tests

### DIFF
--- a/test/support/sws.js
+++ b/test/support/sws.js
@@ -1,14 +1,9 @@
-var stream = require('stream')
-var util = require('util')
+const { Writable } = require('node:stream')
+
+class SlowWriteStream extends Writable {
+  _write (chunk, encoding, callback) {
+    setTimeout(callback, 1000)
+  }
+}
 
 module.exports = SlowWriteStream
-
-function SlowWriteStream () {
-  stream.Writable.call(this)
-}
-
-util.inherits(SlowWriteStream, stream.Writable)
-
-SlowWriteStream.prototype._write = function _write (chunk, encoding, callback) {
-  setTimeout(callback, 1000)
-}


### PR DESCRIPTION
This pull request includes several refactorings and updates to the test suite, focusing on modernizing the codebase by adopting ES6+ features and improving the structure of test utilities. The most important changes include refactoring utility functions, and updating test cases to use the new utility structure.

### ES6+ Modernization:

* [`test/support/sws.js`](diffhunk://#diff-8de516d48e85e63aba2420e836a007bce2ab5f7f55f04ee95a908b60f6d3b974L1-R9): Converted `SlowWriteStream` from a function and `util.inherits` to an ES6 class extending `Writable`.

### Refactoring Utility Functions:

* [`test/support/utils.js`](diffhunk://#diff-737ee29d378169a4e55d95fb8aed8802e82555bb9fd6f14dc3bd0ff8d999e6d7L1-R50): Refactored various utility functions to use ES6 syntax, replaced `var` with `const`/`let`, and consolidated exports into a single `getTestHelpers` function. [[1]](diffhunk://#diff-737ee29d378169a4e55d95fb8aed8802e82555bb9fd6f14dc3bd0ff8d999e6d7L1-R50) [[2]](diffhunk://#diff-737ee29d378169a4e55d95fb8aed8802e82555bb9fd6f14dc3bd0ff8d999e6d7L74-R77) [[3]](diffhunk://#diff-737ee29d378169a4e55d95fb8aed8802e82555bb9fd6f14dc3bd0ff8d999e6d7L114-R110) [[4]](diffhunk://#diff-737ee29d378169a4e55d95fb8aed8802e82555bb9fd6f14dc3bd0ff8d999e6d7L138-R136) [[5]](diffhunk://#diff-737ee29d378169a4e55d95fb8aed8802e82555bb9fd6f14dc3bd0ff8d999e6d7L180-R181)

### Updating Test Cases:

* [`test/test.js`](diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fL1-R178): Updated test cases to use the new `getTestHelpers` function, removed redundant `wrapper` function, and replaced `var` with `const`/`let` for variable declarations. [[1]](diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fL1-R178) [[2]](diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fL228-R285) [[3]](diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fL304-R381) [[4]](diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fL400-R398) [[5]](diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fL418-R442)