### PR TITLE
feat: add contentTypeNegotiation option

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@ unreleased
 
   * feat: add `contentTypeNegotiation` option which enables `text/plain` and `text/html`
     responses based on the `Accept` header
+  * feat: add `defaultContentType` option to configure the default response content type
 
 v2.1.1. / 2025-12-01
 ==================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+  * feat: add `contentTypeNegotiation` option which enables `text/plain` and `text/html`
+    responses based on the `Accept` header
+
 v2.1.1. / 2025-12-01
 ==================
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Provide a function to be called with the `err` when it exists. Can be used for
 writing errors to a central location without excessive function generation. Called
 as `onerror(err, req, res)`.
 
+#### options.contentTypeNegotiation
+
+Enables content type negotiation based on the `Accept` header. When enabled, error
+responses will use `text/plain` or `text/html` based on the client's preferences. Defaults
+to `false`.
+
+> [!WARNING]  
+> This will be enabled by default in the next major version.
+
 ## Examples
 
 ### always 404

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ to `false`.
 > [!WARNING]  
 > This will be enabled by default in the next major version.
 
+#### options.defaultContentType
+
+The fallback content type for responses when content negotiation is disabled or no preferred type can be determined. 
+Allowed Values are `text/html` or `text/plain`. Defaults to `text/html`. 
+
+> [!WARNING]  
+> The default will be changed to `text/plain` in the next major version.
+
 ## Examples
 
 ### always 404

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "debug": "^4.4.0",
     "encodeurl": "^2.0.0",
     "escape-html": "^1.0.3",
+    "negotiator": "^1.0.0",
     "on-finished": "^2.4.1",
     "parseurl": "^1.3.3",
     "statuses": "^2.0.1"

--- a/test/test.js
+++ b/test/test.js
@@ -297,6 +297,139 @@ var topDescribe = function (type, createServer) {
       test.write(buf)
       test.expect(404, done)
     })
+
+    describe('when HTML acceptable', function () {
+      it('should respond with HTML when contentTypeNegotiation is true', function (done) {
+        var server = createServer(null, { contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/html')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(404, /<html/, done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is false', function (done) {
+        var server = createServer(null, { contentTypeNegotiation: false })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/html')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(404, /<html/, done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is not set', function (done) {
+        var server = createServer()
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/html')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(404, /<html/, done)
+      })
+    })
+
+    describe('when plain text acceptable', function () {
+      it('should respond with plain text when contentTypeNegotiation is true', function (done) {
+        var server = createServer(null, { contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/plain')
+          .expect('Content-Type', 'text/plain; charset=utf-8')
+          .expect(404, 'Cannot GET /foo', done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is false', function (done) {
+        var server = createServer(null, { contentTypeNegotiation: false })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/plain')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(404, /<html/, done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is not set', function (done) {
+        var server = createServer()
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/plain')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(404, /<html/, done)
+      })
+    })
+
+    describe('when HTML not acceptable', function () {
+      it('should respond with plain text when contentTypeNegotiation is true', function (done) {
+        var server = createServer(null, { contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'application/x-bogus')
+          .expect('Content-Type', 'text/plain; charset=utf-8')
+          .expect(404, 'Cannot GET /foo', done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is false', function (done) {
+        var server = createServer(null, { contentTypeNegotiation: false })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'application/x-bogus')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(404, /<html/, done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is not set', function (done) {
+        var server = createServer()
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'application/x-bogus')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(404, /<html/, done)
+      })
+    })
+
+    describe('when no Accept header', function () {
+      it('should respond with plain text when contentTypeNegotiation is true', function (done) {
+        var server = createServer(null, { contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .expect('Content-Type', 'text/plain; charset=utf-8')
+          .expect(404, 'Cannot GET /foo', done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is false', function (done) {
+        var server = createServer(null, { contentTypeNegotiation: false })
+        wrapper(request(server)
+          .get('/foo'))
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(404, /<html/, done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is not set', function (done) {
+        var server = createServer()
+        wrapper(request(server)
+          .get('/foo'))
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(404, /<html/, done)
+      })
+    })
+
+    describe('when qualities in Accept header', function () {
+      it('should respond according to quality when contentTypeNegotiation is true', function (done) {
+        var server = createServer(null, { contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/html;q=0.5, text/plain;q=0.9')
+          .expect('Content-Type', 'text/plain; charset=utf-8')
+          .expect(404, 'Cannot GET /foo', done)
+      })
+
+      it('should respond according to quality when contentTypeNegotiation is true', function (done) {
+        var server = createServer(null, { contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/html, application/*;q=0.2, image/jpeg;q=0.8')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(404, /<html/, done)
+      })
+    })
   })
 
   describe('error response', function () {
@@ -392,6 +525,139 @@ var topDescribe = function (type, createServer) {
         test.write(buf)
         test.write(buf)
         test.expect(500, done)
+      })
+    })
+
+    describe('when HTML acceptable', function () {
+      it('should respond with HTML when contentTypeNegotiation is true', function (done) {
+        var server = createServer(createError('boom!'), { contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/html')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(500, /<html/, done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is false', function (done) {
+        var server = createServer(createError('boom!'), { contentTypeNegotiation: false })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/html')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(500, /<html/, done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is not set', function (done) {
+        var server = createServer(createError('boom!'))
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/html')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(500, /<html/, done)
+      })
+    })
+
+    describe('when plain text acceptable', function () {
+      it('should respond with plain text when contentTypeNegotiation is true', function (done) {
+        var server = createServer(createError('boom!'), { env: 'production', contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/plain')
+          .expect('Content-Type', 'text/plain; charset=utf-8')
+          .expect(500, 'Internal Server Error', done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is false', function (done) {
+        var server = createServer(createError('boom!'), { contentTypeNegotiation: false })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/plain')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(500, /<html/, done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is not set', function (done) {
+        var server = createServer(createError('boom!'))
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/plain')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(500, /<html/, done)
+      })
+    })
+
+    describe('when HTML not acceptable', function () {
+      it('should respond with plain text when contentTypeNegotiation is true', function (done) {
+        var server = createServer(createError('boom!'), { env: 'production', contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'application/x-bogus')
+          .expect('Content-Type', 'text/plain; charset=utf-8')
+          .expect(500, 'Internal Server Error', done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is false', function (done) {
+        var server = createServer(createError('boom!'), { env: 'production', contentTypeNegotiation: false })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'application/x-bogus')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(500, /<html/, done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is not set', function (done) {
+        var server = createServer(createError('boom!'), { env: 'production' })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'application/x-bogus')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(500, /<html/, done)
+      })
+    })
+
+    describe('when no Accept header', function () {
+      it('should respond with plain text when contentTypeNegotiation is true', function (done) {
+        var server = createServer(createError('boom!'), { env: 'production', contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .expect('Content-Type', 'text/plain; charset=utf-8')
+          .expect(500, 'Internal Server Error', done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is false', function (done) {
+        var server = createServer(createError('boom!'), { contentTypeNegotiation: false })
+        wrapper(request(server)
+          .get('/foo'))
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(500, /<html/, done)
+      })
+
+      it('should respond with HTML when contentTypeNegotiation is not set', function (done) {
+        var server = createServer(createError('boom!'))
+        wrapper(request(server)
+          .get('/foo'))
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(500, /<html/, done)
+      })
+    })
+
+    describe('when qualities in Accept header', function () {
+      it('should respond according to quality when contentTypeNegotiation is true', function (done) {
+        var server = createServer(createError('boom!'), { env: 'production', contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/html;q=0.5, text/plain;q=0.9')
+          .expect('Content-Type', 'text/plain; charset=utf-8')
+          .expect(500, 'Internal Server Error', done)
+      })
+
+      it('should respond according to quality when contentTypeNegotiation is true', function (done) {
+        var server = createServer(createError('boom!'), { contentTypeNegotiation: true })
+        wrapper(request(server)
+          .get('/foo'))
+          .set('Accept', 'text/html, application/*;q=0.2, image/jpeg;q=0.8')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(500, /<html/, done)
       })
     })
 


### PR DESCRIPTION
This is a backward-compatible version of #85. 

It contains 2 commits: 

- **feat: add contentTypeNegotiation**: Adds a `contentTypeNegotiation` option that enables content type negotiation for error responses based on the `Accept` header. When enabled, responses will be formatted as either `text/plain` or `text/html` according to client preferences. 

- **feat: add defaultContentType option to configure the default response**: Adds a `defaultContentType` option to configure the default response type when content negotiation is disabled or no preferred type can be determined.

The current behaviour (alway returning `text/html` responses) is unchanged but the user can configure it if he wants to. I added 2 warning in the README which states that the options default will be changed in the next major. 