### PR TITLE
fix: respect exposed error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ When an error is written, the following information is added to the response:
     this value is outside the 4xx or 5xx range, it will be set to 500.
   * The `res.statusMessage` is set according to the status code.
   * The body will be the HTML of the status code message if `env` is
-    `'production'`, otherwise will be `err.stack`.
+    `'production'`, unless `err.expose` is true and `err.message` is set.
+    In other environments, the body will be `err.stack`.
   * Any headers specified in an `err.headers` object.
 
 The final handler will also unpipe anything from `req` when it is invoked.

--- a/index.js
+++ b/index.js
@@ -165,6 +165,9 @@ function getErrorMessage (err, status, env) {
     if (!msg && typeof err.toString === 'function') {
       msg = err.toString()
     }
+  } else if (err.expose && typeof err.message === 'string') {
+    // use exposed error messages in production
+    msg = err.message
   }
 
   return msg || statuses.message[status]

--- a/test/test.js
+++ b/test/test.js
@@ -351,6 +351,34 @@ var topDescribe = function (type, createServer) {
         .expect(501, /<pre>Not Implemented<\/pre>/, done)
     })
 
+    it('should send exposed error message when production', function (done) {
+      var err = createError('missing id', {
+        expose: true,
+        status: 400
+      })
+      wrapper(request(createServer(err, {
+        env: 'production'
+      }))
+        .get('/foo'))
+        .expect(400, /<pre>missing id<\/pre>/, done)
+    })
+
+    it('should hide unexposed error message when production', function (done) {
+      var err = createError('secret failure', {
+        expose: false,
+        status: 400
+      })
+      wrapper(request(createServer(err, {
+        env: 'production'
+      }))
+        .get('/foo'))
+        .expect(400, /<pre>Bad Request<\/pre>/)
+        .expect(function (res) {
+          assert.strictEqual(res.text.indexOf('secret failure'), -1)
+        })
+        .end(done)
+    })
+
     describe('when there is a request body', function () {
       it('should not hang/error when unread', function (done) {
         var buf = Buffer.alloc(1024 * 16, '.')


### PR DESCRIPTION
Uses `err.message` for production responses when an error explicitly sets `err.expose`.

This keeps the existing behavior for non-production responses, where stacks are shown, and keeps production 5xx/unexposed errors hidden behind the status message. It gives callers using `http-errors` or similar libraries the documented way to expose safe 4xx messages.

Refs #24.

Verification:
- `npm test` (110 passing, 4 pending)
- `npm run lint`
- `git diff --check`