### PR TITLE
feat: support optimizeEmptyRequests node option handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debug": "^4.4.3",
     "encodeurl": "^2.0.0",
     "escape-html": "^1.0.3",
-    "on-finished": "^2.4.1",
+    "on-finished": "jshttp/on-finished#v3",
     "parseurl": "^1.3.3",
     "statuses": "^2.0.2"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -662,6 +662,52 @@ var topDescribe = function (type, createServer) {
   })
 }
 
+describe('with optimizeEmptyRequests', function () {
+  function requestFinalhandler (method, callback) {
+    var server = http.createServer({ optimizeEmptyRequests: true }, function (req, res) {
+      finalhandler(req, res)()
+    })
+
+    server.listen(0, function () {
+      var port = this.address().port
+      var settled = false
+      var finish = function (err, statusCode) {
+        if (settled) return
+        settled = true
+        server.close()
+        callback(err, statusCode)
+      }
+
+      var req = http.request({ host: '127.0.0.1', port: port, path: '/foo', method: method }, function (res) {
+        res.resume()
+        res.on('end', function () { finish(null, res.statusCode) })
+      })
+      req.on('error', finish)
+      req.setTimeout(1000, function () {
+        req.destroy()
+        finish(new Error('finalhandler never sent a response (on-finished did not fire for the dumped request)'))
+      })
+      req.end()
+    })
+  }
+
+  it('should still send a 404 for a body-less GET request', function (done) {
+    requestFinalhandler('GET', function (err, statusCode) {
+      if (err) return done(err)
+      assert.strictEqual(statusCode, 404)
+      done()
+    })
+  })
+
+  it('should still send a 404 for a body-less HEAD request', function (done) {
+    requestFinalhandler('HEAD', function (err, statusCode) {
+      if (err) return done(err)
+      assert.strictEqual(statusCode, 404)
+      done()
+    })
+  })
+})
+
 var servers = [
   ['http', createHTTPServer],
   ['http2', createHTTP2Server]


### PR DESCRIPTION
finalhandler is used as a callback in the router's handler when there’s no error handler or callback (https://github.com/expressjs/express/blob/2eb42059f33d9be6ead3bb813d05aa975283d592/lib/application.js#L154), and for some reason, the response wasn’t finishing. When I realized it, the on-finished callback was never triggered (https://github.com/pillarjs/finalhandler/blob/62cc7e03dcf3da1983f79a1144737b3bb281fc7c/index.js#L291 or https://github.com/pillarjs/finalhandler/blob/62cc7e03dcf3da1983f79a1144737b3bb281fc7c/index.js#L282), which was the one used to mark the request as completed.

ref: https://openjs-foundation.slack.com/archives/C08QG8K2RTJ/p1757863264523329
ref: https://github.com/expressjs/express/pull/6742