### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,9 @@
     "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test",
     "test-inspect": "mocha --reporter spec --inspect --inspect-brk test/"
+  },
+  "homepage": "https://github.com/pillarjs/finalhandler",
+  "bugs": {
+    "url": "https://github.com/pillarjs/finalhandler/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.