### PR TITLE
fix: prevent writing after response headers are sent

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==================
 
+  * Prevent writing a response after headers are sent while flushing the request
   * deps: 
     * debug@^4.4.3
     * statuses@^2.0.2

--- a/index.js
+++ b/index.js
@@ -243,6 +243,11 @@ function getResponseStatusCode (res) {
 
 function send (req, res, status, headers, message) {
   function write () {
+    if (res.headersSent) {
+      debug('cannot %d after headers sent', status)
+      return
+    }
+
     // response body
     var body = createHtmlDocument(message)
 

--- a/test/test.js
+++ b/test/test.js
@@ -526,19 +526,14 @@ var topDescribe = function (type, createServer) {
 
   describe('request started', function () {
     it('should not respond after headers are sent while flushing the request', function (done) {
-      var buf = Buffer.alloc(1024 * 16, '.')
       var server = createServer(function (req, res) {
-        var final = finalhandler(req, res)
-
-        final()
-        final()
+        finalhandler(req, res)()
+        res.end('respond not by finalhandler')
       })
 
-      var test = wrapper(request(server).post('/foo'))
-      test.write(buf)
-      test.write(buf)
-      test.write(buf)
-      test.expect(404, done)
+      wrapper(request(server)
+        .post('/foo'))
+        .expect(200, 'respond not by finalhandler', done)
     })
 
     it('should not respond', function (done) {

--- a/test/test.js
+++ b/test/test.js
@@ -525,6 +525,22 @@ var topDescribe = function (type, createServer) {
   })
 
   describe('request started', function () {
+    it('should not respond after headers are sent while flushing the request', function (done) {
+      var buf = Buffer.alloc(1024 * 16, '.')
+      var server = createServer(function (req, res) {
+        var final = finalhandler(req, res)
+
+        final()
+        final()
+      })
+
+      var test = wrapper(request(server).post('/foo'))
+      test.write(buf)
+      test.write(buf)
+      test.write(buf)
+      test.expect(404, done)
+    })
+
     it('should not respond', function (done) {
       var server = createServer(function (req, res) {
         var done = finalhandler(req, res)


### PR DESCRIPTION
Fixes https://github.com/pillarjs/finalhandler/issues/162

## Changes

Check `res.headersSent` at the beginning of the `write()` callback invoked by `onFinished`.

If the response headers have already been sent, stop without writing to the response. This prevents finalhandler from modifying a response sent by another operation and avoids `ERR_HTTP_HEADERS_SENT`.

The existing behavior of reading the complete request body remains unchanged.
